### PR TITLE
Change Arial to Liberation Sans in Marker.cpp

### DIFF
--- a/src/ogre_visuals/marker.cpp
+++ b/src/ogre_visuals/marker.cpp
@@ -95,7 +95,7 @@ namespace marker_rviz_plugin {
         } else {
             ss << "-";
         }
-        text_ = new rviz::MovableText(ss.str(), "Arial", 0.4);
+        text_ = new rviz::MovableText(ss.str(), "Liberation Sans", 0.4);
         text_->setTextAlignment(rviz::MovableText::H_CENTER, rviz::MovableText::V_BELOW);
         text_->setColor(Ogre::ColourValue(0.70, 0.70, 0.70));
 


### PR DESCRIPTION
Liberation Sans is now distributed with rviz, not Arial. Using Arial results in

```
terminate called after throwing an instance of 'Ogre::Exception'
  what():  OGRE EXCEPTION(5:): Could not find font Arial in MovableText::setFontName
Aborted
```